### PR TITLE
Add robust epoll disconnect handling

### DIFF
--- a/include/server.hpp
+++ b/include/server.hpp
@@ -3,6 +3,7 @@
 
 #include <sys/epoll.h>
 #include <vector>
+#include <csignal>
 #include "client.hpp"
 
 class Server
@@ -13,7 +14,7 @@ private:
     int epoll_fd_;
     std::vector<Client> clients_;
 
-    static bool running;
+    volatile static std::sig_atomic_t running;
 
     void InitListeningSocket();
     void InitEpollInstance();

--- a/src/server/init.cpp
+++ b/src/server/init.cpp
@@ -32,9 +32,7 @@ void Server::HandleSignals() {
         throw std::runtime_error("failed to set sigaction for SIGINT");
 }
 
-bool Server::running = true;
 void Server::SignalHandler(int signum) {
-    std::cout << " Signal <" << signum << "> was caught" << std::endl;
     Server::running = false;
 }
 


### PR DESCRIPTION
Handle EPOLLRDHUP/EPOLLHUP/EPOLLERR early in the epoll loop so clients are disconnected immediately when the peer closes the socket. Also use sig_atomic_t for the running flag and avoid printing inside the signal handler.